### PR TITLE
manually calling node-gyp is not needed anymore with recent npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     }, 
     "engines": {
         "node" : ">=0.6.0"
-    },
-    "scripts": {
-        "install": "node-gyp configure && node-gyp build"
     }
 }
 


### PR DESCRIPTION
npm will run node-gyp when it finds a binding.gyp in the module, so manually calling node-gyp is not needed anymore.

on a side note, there is currently no 'test' entry in the package.json even though there is a (simple) test present.
